### PR TITLE
DEV-306 MAC ID not showing in Consensys config window if BT connected while undocked

### DIFF
--- a/Configuration/shimmer_config.c
+++ b/Configuration/shimmer_config.c
@@ -721,10 +721,8 @@ void ShimConfig_createBlankConfigBytes(void)
   /* Make all calibration bytes invalid (i.e., 0xFF) */
   memset(storedConfig.lnAccelCalib.rawBytes, 0xFF,
       sizeof(storedConfig.lnAccelCalib.rawBytes));
-  memset(storedConfig.gyroCalib.rawBytes, 0xFF,
-      sizeof(storedConfig.gyroCalib.rawBytes));
-  memset(storedConfig.magCalib.rawBytes, 0xFF,
-      sizeof(storedConfig.magCalib.rawBytes));
+  memset(storedConfig.gyroCalib.rawBytes, 0xFF, sizeof(storedConfig.gyroCalib.rawBytes));
+  memset(storedConfig.magCalib.rawBytes, 0xFF, sizeof(storedConfig.magCalib.rawBytes));
   memset(storedConfig.wrAccelCalib.rawBytes, 0xFF,
       sizeof(storedConfig.wrAccelCalib.rawBytes));
   memset(storedConfig.altAccelCalib.rawBytes, 0xFF,

--- a/Configuration/shimmer_config.c
+++ b/Configuration/shimmer_config.c
@@ -151,8 +151,7 @@ uint8_t ShimConfig_storedConfigSetByte(uint16_t offset, uint8_t val)
 
 void ShimConfig_setDefaultConfig(void)
 {
-  storedConfig = ShimConfig_createBlankConfigBytes();
-
+  ShimConfig_createBlankConfigBytes();
   storedConfig.samplingRateTicks = ShimConfig_freqDiv(51.2); //51.2Hz
   storedConfig.bufferSize = 1;
   /* core sensors enabled */
@@ -675,7 +674,6 @@ void ShimConfig_loadSensorConfigAndCalib(void)
 {
   ShimCalib_init();
   ShimCalib_initFromConfigBytesAll();
-
   if (!shimmerStatus.docked && CheckSdInslot())
   { //sd card ready to access
     if (!shimmerStatus.sdPowerOn)
@@ -716,17 +714,17 @@ void ShimConfig_loadSensorConfigAndCalib(void)
   ShimCalib_calibDumpToConfigBytesAndSdHeaderAll(1);
 }
 
-gConfigBytes ShimConfig_createBlankConfigBytes(void)
+void ShimConfig_createBlankConfigBytes(void)
 {
-  gConfigBytes storedConfigNew;
-
-  memset(&storedConfigNew.rawBytes[NV_SAMPLING_RATE], 0, STOREDCONFIG_SIZE);
+  memset(&storedConfig.rawBytes[0], 0, STOREDCONFIG_SIZE);
 
   /* Make all calibration bytes invalid (i.e., 0xFF) */
   memset(storedConfig.lnAccelCalib.rawBytes, 0xFF,
       sizeof(storedConfig.lnAccelCalib.rawBytes));
-  memset(storedConfig.gyroCalib.rawBytes, 0xFF, sizeof(storedConfig.gyroCalib.rawBytes));
-  memset(storedConfig.magCalib.rawBytes, 0xFF, sizeof(storedConfig.magCalib.rawBytes));
+  memset(storedConfig.gyroCalib.rawBytes, 0xFF,
+      sizeof(storedConfig.gyroCalib.rawBytes));
+  memset(storedConfig.magCalib.rawBytes, 0xFF,
+      sizeof(storedConfig.magCalib.rawBytes));
   memset(storedConfig.wrAccelCalib.rawBytes, 0xFF,
       sizeof(storedConfig.wrAccelCalib.rawBytes));
   memset(storedConfig.altAccelCalib.rawBytes, 0xFF,
@@ -735,17 +733,15 @@ gConfigBytes ShimConfig_createBlankConfigBytes(void)
       sizeof(storedConfig.altMagCalib.rawBytes));
 
   /* Copy MAC ID directly from BT module */
-  memcpy(&storedConfigNew.macAddr[0], ShimBt_macIdBytesPtrGet(), 6);
+  memcpy(&storedConfig.macAddr[0], ShimBt_macIdBytesPtrGet(), 6);
 
   /* Reset unused bytes */
-  memset(&storedConfigNew.rawBytes[NV_BT_SET_PIN + 1], 0xFF, 24);
+  memset(&storedConfig.rawBytes[NV_BT_SET_PIN + 1], 0xFF, 24);
 
   /* Reset node addresses */
-  memset(&storedConfigNew.rawBytes[NV_CENTER], 0xFF, 128);
+  memset(&storedConfig.rawBytes[NV_CENTER], 0xFF, 128);
 
-  memset(storedConfig.rawBytes, 0x00, sizeof(storedConfig.rawBytes));
-
-  return storedConfigNew;
+  return;
 }
 
 uint8_t ShimConfig_areConfigBytesValid(void)

--- a/Configuration/shimmer_config.h
+++ b/Configuration/shimmer_config.h
@@ -521,7 +521,7 @@ uint8_t ShimConfig_isMicrophoneEnabled(void);
 uint8_t ShimConfig_isGSREnabled(void);
 uint8_t ShimConfig_isExpansionBoardPwrEnabled(void);
 void ShimConfig_loadSensorConfigAndCalib(void);
-gConfigBytes ShimConfig_createBlankConfigBytes(void);
+void ShimConfig_createBlankConfigBytes(void);
 uint8_t ShimConfig_areConfigBytesValid(void);
 
 void ShimConfig_parseShimmerNameFromConfigBytes(void);

--- a/SDCard/shimmer_sd_cfg_file.c
+++ b/SDCard/shimmer_sd_cfg_file.c
@@ -370,7 +370,7 @@ void ShimSdCfgFile_parse(void)
     /* update  stored_config_temp with original storedConfig contents before
     parsing from cfg file to check and update the values from cfg_file */
     memcpy(&(stored_config_temp.rawBytes[0]), &(storedConfig->rawBytes[0]), STOREDCONFIG_SIZE);
-    // Reset global configuration bytes to a blank state before parsing the config file.
+    //Reset global configuration bytes to a blank state before parsing the config file.
     ShimConfig_createBlankConfigBytes();
     ShimSdSync_resetSyncVariablesBeforeParseConfig();
     ShimSdSync_resetSyncNodeArray();

--- a/SDCard/shimmer_sd_cfg_file.c
+++ b/SDCard/shimmer_sd_cfg_file.c
@@ -370,6 +370,7 @@ void ShimSdCfgFile_parse(void)
     /* update  stored_config_temp with original storedConfig contents before
     parsing from cfg file to check and update the values from cfg_file */
     memcpy(&(stored_config_temp.rawBytes[0]), &(storedConfig->rawBytes[0]), STOREDCONFIG_SIZE);
+    // Reset global configuration bytes to a blank state before parsing the config file.
     ShimConfig_createBlankConfigBytes();
     ShimSdSync_resetSyncVariablesBeforeParseConfig();
     ShimSdSync_resetSyncNodeArray();

--- a/SDCard/shimmer_sd_cfg_file.c
+++ b/SDCard/shimmer_sd_cfg_file.c
@@ -348,7 +348,8 @@ void ShimSdCfgFile_parse(void)
   uint8_t triggerSdCardUpdate = 0;
 
   CheckSdInslot();
-  gConfigBytes *storedConfig = ShimConfig_getStoredConfig(); // get the pointer as variable is not accessible
+  gConfigBytes *storedConfig
+      = ShimConfig_getStoredConfig(); //get the pointer as variable is not accessible
   char cfgname[] = "sdlog.cfg";
   cfg_file_status = f_open(&cfgFile, cfgname, FA_READ | FA_OPEN_EXISTING);
   if (cfg_file_status == FR_NO_FILE)
@@ -366,9 +367,9 @@ void ShimSdCfgFile_parse(void)
   else
   {
     gConfigBytes stored_config_temp;
-    /* update  stored_config_temp with original storedConfig contents before parsing from cfg file to check and
-    update the values from cfg_file */
-    memcpy(&(stored_config_temp.rawBytes[0]),&(storedConfig->rawBytes[0]),STOREDCONFIG_SIZE);
+    /* update  stored_config_temp with original storedConfig contents before
+    parsing from cfg file to check and update the values from cfg_file */
+    memcpy(&(stored_config_temp.rawBytes[0]), &(storedConfig->rawBytes[0]), STOREDCONFIG_SIZE);
     ShimConfig_createBlankConfigBytes();
     ShimSdSync_resetSyncVariablesBeforeParseConfig();
     ShimSdSync_resetSyncNodeArray();
@@ -829,24 +830,23 @@ void ShimSdCfgFile_parse(void)
     stored_config_temp.samplingRateTicks = (uint16_t) sample_period;
     /* restoring orignal calibration bytes which is not updated from calib file*/
     memcpy((storedConfig->lnAccelCalib.rawBytes),
-           &(stored_config_temp.lnAccelCalib.rawBytes),
-           sizeof(stored_config_temp.lnAccelCalib.rawBytes));
-    memcpy((storedConfig->gyroCalib.rawBytes),
-           &(stored_config_temp.gyroCalib.rawBytes),
-           sizeof(stored_config_temp.gyroCalib.rawBytes));
-    memcpy((storedConfig->magCalib.rawBytes),
-           &(stored_config_temp.magCalib.rawBytes),
-           sizeof(stored_config_temp.magCalib.rawBytes));
+        &(stored_config_temp.lnAccelCalib.rawBytes),
+        sizeof(stored_config_temp.lnAccelCalib.rawBytes));
+    memcpy((storedConfig->gyroCalib.rawBytes), &(stored_config_temp.gyroCalib.rawBytes),
+        sizeof(stored_config_temp.gyroCalib.rawBytes));
+    memcpy((storedConfig->magCalib.rawBytes), &(stored_config_temp.magCalib.rawBytes),
+        sizeof(stored_config_temp.magCalib.rawBytes));
     memcpy((storedConfig->wrAccelCalib.rawBytes),
-           &(stored_config_temp.wrAccelCalib.rawBytes),
-           sizeof(stored_config_temp.wrAccelCalib.rawBytes));
+        &(stored_config_temp.wrAccelCalib.rawBytes),
+        sizeof(stored_config_temp.wrAccelCalib.rawBytes));
     memcpy((storedConfig->altAccelCalib.rawBytes),
-           &(stored_config_temp.altAccelCalib.rawBytes),
-           sizeof(stored_config_temp.altAccelCalib.rawBytes));
+        &(stored_config_temp.altAccelCalib.rawBytes),
+        sizeof(stored_config_temp.altAccelCalib.rawBytes));
     memcpy((storedConfig->altMagCalib.rawBytes),
-           &(stored_config_temp.altMagCalib.rawBytes),
-           sizeof(stored_config_temp.altMagCalib.rawBytes));
-    triggerSdCardUpdate |= ShimConfig_checkAndCorrectConfig(ShimConfig_getStoredConfig());
+        &(stored_config_temp.altMagCalib.rawBytes),
+        sizeof(stored_config_temp.altMagCalib.rawBytes));
+    triggerSdCardUpdate
+        |= ShimConfig_checkAndCorrectConfig(ShimConfig_getStoredConfig());
 
     LogAndStream_infomemUpdate();
 

--- a/SDCard/shimmer_sd_cfg_file.c
+++ b/SDCard/shimmer_sd_cfg_file.c
@@ -348,7 +348,7 @@ void ShimSdCfgFile_parse(void)
   uint8_t triggerSdCardUpdate = 0;
 
   CheckSdInslot();
-
+  gConfigBytes *storedConfig = ShimConfig_getStoredConfig(); // get the pointer as variable is not accessible
   char cfgname[] = "sdlog.cfg";
   cfg_file_status = f_open(&cfgFile, cfgname, FA_READ | FA_OPEN_EXISTING);
   if (cfg_file_status == FR_NO_FILE)
@@ -365,8 +365,11 @@ void ShimSdCfgFile_parse(void)
   }
   else
   {
-    gConfigBytes stored_config_temp = ShimConfig_createBlankConfigBytes();
-
+    gConfigBytes stored_config_temp;
+    /* update  stored_config_temp with original storedConfig contents before parsing from cfg file to check and
+    update the values from cfg_file */
+    memcpy(&(stored_config_temp.rawBytes[0]),&(storedConfig->rawBytes[0]),STOREDCONFIG_SIZE);
+    ShimConfig_createBlankConfigBytes();
     ShimSdSync_resetSyncVariablesBeforeParseConfig();
     ShimSdSync_resetSyncNodeArray();
 
@@ -822,28 +825,28 @@ void ShimSdCfgFile_parse(void)
 #elif defined(SHIMMER3R)
     HAL_Delay(50); //50ms
 #endif
-
     sample_period = (round) (ShimConfig_freqDiv(sample_rate));
     stored_config_temp.samplingRateTicks = (uint16_t) sample_period;
-
-    triggerSdCardUpdate |= ShimConfig_checkAndCorrectConfig(&stored_config_temp);
-
-    /* Calibration bytes are not copied over from the temporary config bytes */
-    /* Infomem D - Bytes 0-33 - General settings */
-    gConfigBytes *storedConfig = ShimConfig_getStoredConfig();
-    memcpy(&storedConfig->rawBytes[0], &stored_config_temp.rawBytes[0], NV_NUM_SETTINGS_BYTES);
-    /* Infomem D - Bytes 118-122 - Derived channel settings */
-    memcpy(&storedConfig->rawBytes[NV_DERIVED_CHANNELS_3],
-        &stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_3], 5);
-    /* Infomem C - Bytes 128-132 - MPL related settings - no longer used/supported */
-    memcpy(&storedConfig->rawBytes[NV_SENSORS3],
-        &stored_config_temp.rawBytes[NV_SENSORS3], 5);
-    /* Infomem C - Bytes 187-223 - Shimmer name, exp ID, config time, trial ID, num Shimmers, trial config, BT interval, est exp len, max exp len */
-    memcpy(&storedConfig->rawBytes[NV_SD_SHIMMER_NAME],
-        &stored_config_temp.rawBytes[NV_SD_SHIMMER_NAME], 37);
-    /* Infomem B - Bytes 256-381 - Center and Node MAC addresses */
-    memcpy(&storedConfig->rawBytes[NV_CENTER],
-        &stored_config_temp.rawBytes[NV_CENTER], NV_NUM_BYTES_SYNC_CENTER_NODE_ADDRS);
+    /* restoring orignal calibration bytes which is not updated from calib file*/
+    memcpy((storedConfig->lnAccelCalib.rawBytes),
+           &(stored_config_temp.lnAccelCalib.rawBytes),
+           sizeof(stored_config_temp.lnAccelCalib.rawBytes));
+    memcpy((storedConfig->gyroCalib.rawBytes),
+           &(stored_config_temp.gyroCalib.rawBytes),
+           sizeof(stored_config_temp.gyroCalib.rawBytes));
+    memcpy((storedConfig->magCalib.rawBytes),
+           &(stored_config_temp.magCalib.rawBytes),
+           sizeof(stored_config_temp.magCalib.rawBytes));
+    memcpy((storedConfig->wrAccelCalib.rawBytes),
+           &(stored_config_temp.wrAccelCalib.rawBytes),
+           sizeof(stored_config_temp.wrAccelCalib.rawBytes));
+    memcpy((storedConfig->altAccelCalib.rawBytes),
+           &(stored_config_temp.altAccelCalib.rawBytes),
+           sizeof(stored_config_temp.altAccelCalib.rawBytes));
+    memcpy((storedConfig->altMagCalib.rawBytes),
+           &(stored_config_temp.altMagCalib.rawBytes),
+           sizeof(stored_config_temp.altMagCalib.rawBytes));
+    triggerSdCardUpdate |= ShimConfig_checkAndCorrectConfig(ShimConfig_getStoredConfig());
 
     LogAndStream_infomemUpdate();
 


### PR DESCRIPTION
MACID 0000 was because MACID in infomem was stored as 0000 when the cfg file was parsed , now  configbytes are written with correct macid  at
 triggerSdCardUpdate
        |= ShimConfig_checkAndCorrectConfig(ShimConfig_getStoredConfig());
        
        as well as 
    memcpy(&storedConfig.macAddr[0], ShimBt_macIdBytesPtrGet(), 6);  
    
        