### PR TITLE
DEV-394_config resets everytime when powercycled 

### DIFF
--- a/Comms/shimmer_dock_usart.c
+++ b/Comms/shimmer_dock_usart.c
@@ -368,7 +368,7 @@ void ShimDock_processCmd(void)
                 ShimConfig_storedConfigSet(dockRxBuf + UART_RXBUF_DATA + 3,
                     uartInfoMemOffset, uartInfoMemLength);
 
-                ShimConfig_checkAndCorrectConfig(ShimConfig_getStoredConfig());
+                ShimConfig_checkAndCorrectConfig();
                 ShimConfig_setFlagWriteCfgToSd(1, 0);
 
                 LogAndStream_infomemUpdate();

--- a/Configuration/shimmer_config.c
+++ b/Configuration/shimmer_config.c
@@ -93,6 +93,7 @@ void ShimConfig_readRam(void)
   }
 #endif //USE_DEFAULT_SENSOR
 
+  //TODO ShimConfig_checkBtModeFromConfig should be called at a higher level and from a single place
   /* Check BT module configuration after sensor configuration read from
    * infomem to see if it is in the correct state (i.e., BT on vs. BT off vs.
    * SD Sync) */
@@ -165,33 +166,33 @@ void ShimConfig_setDefaultConfig(void)
   storedConfig.wrAccelRate = LSM303DLHC_ACCEL_100HZ;
   storedConfig.wrAccelRange = ACCEL_2G;
   storedConfig.wrAccelHrMode = 0;
-  ShimConfig_wrAccelLpModeSet(&storedConfig, 0);
+  ShimConfig_wrAccelLpModeSet(0);
   /* MPU9X50/ICM20948 sampling rate of 8kHz/(155+1), i.e. 51.282Hz */
-  ShimConfig_gyroRateSet(&storedConfig, 0x9B);
+  ShimConfig_gyroRateSet(0x9B);
   /* LSM303 Mag 75Hz, +/-1.3 Gauss, MPU9150 Gyro +/-500 degrees per second */
   storedConfig.magRange = LSM303DLHC_MAG_1_3G;
-  ShimConfig_configByteMagRateSet(&storedConfig, LSM303DLHC_MAG_75HZ);
-  ShimConfig_gyroRangeSet(&storedConfig, MPU9X50_GYRO_500DPS);
+  ShimConfig_configByteMagRateSet(LSM303DLHC_MAG_75HZ);
+  ShimConfig_gyroRangeSet(MPU9X50_GYRO_500DPS);
   /* MPU9X50/ICM20948 Accel +/-2G */
   storedConfig.altAccelRange = ACCEL_2G;
   /* BMP pressure oversampling ratio 1 */
-  ShimConfig_configBytePressureOversamplingRatioSet(&storedConfig, BMPX80_OSS_1);
+  ShimConfig_configBytePressureOversamplingRatioSet(BMPX80_OSS_1);
 #elif defined(SHIMMER3R)
   /* LIS2DW12 Accel 100Hz, +/-2G, Low Power and High Resolution modes off */
   storedConfig.wrAccelRate = LIS2DW12_XL_ODR_100Hz;
   storedConfig.wrAccelRange = LIS2DW12_2g;
-  ShimConfig_wrAccelModeSet(&storedConfig, LIS2DW12_HIGH_PERFORMANCE);
+  ShimConfig_wrAccelModeSet(LIS2DW12_HIGH_PERFORMANCE);
   /* LSM6DSV Gyro sampling rate, next highest to 51.2Hz */
-  ShimConfig_gyroRateSet(&storedConfig, LSM6DSV_ODR_AT_60Hz);
+  ShimConfig_gyroRateSet(LSM6DSV_ODR_AT_60Hz);
   /* LIS2MDL Mag 100Hz */
-  ShimConfig_configByteMagRateSet(&storedConfig, LIS2MDL_ODR_100Hz);
+  ShimConfig_configByteMagRateSet(LIS2MDL_ODR_100Hz);
   /* LIS3MDL Mag 80Hz, +/-4 Gauss */
   storedConfig.altMagRange = LIS3MDL_4_GAUSS;
-  ShimConfig_configByteAltMagRateSet(&storedConfig, LIS3MDL_UHP_80Hz);
+  ShimConfig_configByteAltMagRateSet(LIS3MDL_UHP_80Hz);
   /* LSM6DSV Gyro +/-500 degrees per second */
-  ShimConfig_gyroRangeSet(&storedConfig, LSM6DSV_500dps);
+  ShimConfig_gyroRangeSet(LSM6DSV_500dps);
   storedConfig.lnAccelRange = LSM6DSV_2g;
-  ShimConfig_configBytePressureOversamplingRatioSet(&storedConfig, BMP3_NO_OVERSAMPLING);
+  ShimConfig_configBytePressureOversamplingRatioSet(BMP3_NO_OVERSAMPLING);
 #endif
   /* GSR auto range */
   storedConfig.gsrRange = GSR_AUTORANGE;
@@ -200,8 +201,8 @@ void ShimConfig_setDefaultConfig(void)
   storedConfig.expansionBoardPower = 0;
 
   //set all ExG registers to their reset values
-  //setExgConfigForTestSignal(&storedConfig);
-  ShimConfig_setExgConfigForEcg(&storedConfig);
+  //setExgConfigForTestSignal();
+  ShimConfig_setExgConfigForEcg();
 
   /*BT Baud Rate*/
   if (storedConfig.btCommsBaudRate == 0xFF)
@@ -231,7 +232,7 @@ void ShimConfig_setDefaultConfig(void)
   ShimConfig_experimentLengthEstimatedInSecSet(1);
   ShimSdSync_setSyncEstExpLen((uint32_t) ShimConfig_experimentLengthEstimatedInSecGet());
 
-  ShimConfig_checkAndCorrectConfig(&storedConfig);
+  ShimConfig_checkAndCorrectConfig();
   ShimConfig_setFlagWriteCfgToSd(1, 0);
 
   ShimCalib_calibDumpToConfigBytesAndSdHeaderAll(0);
@@ -253,16 +254,16 @@ void ShimConfig_setDefaultTrialId(void)
 
 void ShimConfig_setDefaultConfigTime(void)
 {
-  ShimConfig_configTimeSet(&storedConfig, 0);
+  ShimConfig_configTimeSet(0);
 }
 
-void ShimConfig_configTimeSet(gConfigBytes *storedConfigPtr, uint32_t time)
+void ShimConfig_configTimeSet(uint32_t time)
 {
   //Config time is stored in MSB order in the config bytes
-  storedConfigPtr->configTime0 = (time >> 24) & 0xFF;
-  storedConfigPtr->configTime1 = (time >> 16) & 0xFF;
-  storedConfigPtr->configTime2 = (time >> 8) & 0xFF;
-  storedConfigPtr->configTime3 = (time >> 0) & 0xFF;
+  storedConfig.configTime0 = (time >> 24) & 0xFF;
+  storedConfig.configTime1 = (time >> 16) & 0xFF;
+  storedConfig.configTime2 = (time >> 8) & 0xFF;
+  storedConfig.configTime3 = (time >> 0) & 0xFF;
 }
 
 uint32_t ShimConfig_configTimeGet(void)
@@ -307,16 +308,16 @@ float ShimConfig_getShimmerSamplingFreq(void)
   return 32768.0 / (float) storedConfig.samplingRateTicks;
 }
 
-void ShimConfig_gyroRangeSet(gConfigBytes *storedConfigPtr, uint8_t value)
+void ShimConfig_gyroRangeSet(uint8_t value)
 {
 #if defined(SHIMMER3)
   value = (value <= MPU9X50_GYRO_2000DPS) ? value : MPU9X50_GYRO_500DPS;
 #elif defined(SHIMMER3R)
   value = (value <= (LSM6DSV_2000dps + 1)) ? value : LSM6DSV_500dps;
 #endif
-  storedConfigPtr->gyroRangeLsb = value & 0x03;
+  storedConfig.gyroRangeLsb = value & 0x03;
 #if defined(SHIMMER3R)
-  storedConfigPtr->gyroRangeMsb = (value >> 2) & 0x01;
+  storedConfig.gyroRangeMsb = (value >> 2) & 0x01;
 #endif
 }
 
@@ -329,24 +330,24 @@ uint8_t ShimConfig_gyroRangeGet(void)
 #endif
 }
 
-void ShimConfig_gyroRateSet(gConfigBytes *storedConfigPtr, uint8_t value)
+void ShimConfig_gyroRateSet(uint8_t value)
 {
 #if defined(SHIMMER3R)
   value = (value < LSM6DSV_ODR_AT_7680Hz) ? value : LSM6DSV_ODR_AT_60Hz;
 #endif
-  storedConfigPtr->gyroRate = value;
+  storedConfig.gyroRate = value;
 }
 
-void ShimConfig_wrAccelLpModeSet(gConfigBytes *storedConfigPtr, uint8_t value)
+void ShimConfig_wrAccelLpModeSet(uint8_t value)
 {
 #if defined(SHIMMER3)
   value = (value == 1) ? 1 : 0;
 #elif defined(SHIMMER3R)
   value = (value <= 3) ? value : 0;
 #endif
-  storedConfigPtr->wrAccelLpModeLsb = value & 0x01;
+  storedConfig.wrAccelLpModeLsb = value & 0x01;
 #if defined(SHIMMER3R)
-  storedConfigPtr->wrAccelLpModeMsb = (value >> 1) & 0x01;
+  storedConfig.wrAccelLpModeMsb = (value >> 1) & 0x01;
 #endif
 }
 
@@ -360,10 +361,10 @@ uint8_t ShimConfig_wrAccelLpModeGet(void)
 }
 
 #if defined(SHIMMER3R)
-void ShimConfig_wrAccelModeSet(gConfigBytes *storedConfigPtr, lis2dw12_mode_t value)
+void ShimConfig_wrAccelModeSet(lis2dw12_mode_t value)
 {
-  storedConfigPtr->wrAccelHrMode = (value >> 2) & 0x01;
-  ShimConfig_wrAccelLpModeSet(storedConfigPtr, value & 0x03);
+  storedConfig.wrAccelHrMode = (value >> 2) & 0x01;
+  ShimConfig_wrAccelLpModeSet(value & 0x03);
 }
 
 lis2dw12_mode_t ShimConfig_wrAccelModeGet(void)
@@ -374,16 +375,16 @@ lis2dw12_mode_t ShimConfig_wrAccelModeGet(void)
 }
 #endif
 
-void ShimConfig_configBytePressureOversamplingRatioSet(gConfigBytes *storedConfigPtr, uint8_t value)
+void ShimConfig_configBytePressureOversamplingRatioSet(uint8_t value)
 {
 #if defined(SHIMMER3)
   value = (value <= BMPX80_OSS_8) ? (value & 0x03) : BMPX80_OSS_1;
 #elif defined(SHIMMER3R)
   value = (value <= BMP3_OVERSAMPLING_32X) ? value : BMP3_NO_OVERSAMPLING;
 #endif
-  storedConfigPtr->pressureOversamplingRatioLsb = value & 0x03;
+  storedConfig.pressureOversamplingRatioLsb = value & 0x03;
 #if defined(SHIMMER3R)
-  storedConfigPtr->pressureOversamplingRatioMsb = (value >> 2) & 0x01;
+  storedConfig.pressureOversamplingRatioMsb = (value >> 2) & 0x01;
 #endif
 }
 
@@ -397,14 +398,14 @@ uint8_t ShimConfig_configBytePressureOversamplingRatioGet(void)
 #endif
 }
 
-void ShimConfig_configByteMagRateSet(gConfigBytes *storedConfigPtr, uint8_t value)
+void ShimConfig_configByteMagRateSet(uint8_t value)
 {
 #if defined(SHIMMER3)
   value = (value < LSM303DLHC_MAG_220HZ) ? value : LSM303DLHC_MAG_75HZ;
 #else
   value = (value <= LIS2MDL_ODR_100Hz) ? value : LIS2MDL_ODR_100Hz;
 #endif
-  storedConfigPtr->magRate = value;
+  storedConfig.magRate = value;
 }
 
 uint8_t ShimConfig_configByteMagRateGet(void)
@@ -412,14 +413,14 @@ uint8_t ShimConfig_configByteMagRateGet(void)
   return storedConfig.magRate;
 }
 
-void ShimConfig_configByteAltMagRateSet(gConfigBytes *storedConfigPtr, uint8_t value)
+void ShimConfig_configByteAltMagRateSet(uint8_t value)
 {
 #if defined(SHIMMER3)
   value = 0; //not used
 #elif defined(SHIMMER3R)
   value = value <= (LIS3MDL_UHP_80Hz) ? value : LIS3MDL_UHP_80Hz;
 #endif
-  storedConfigPtr->altMagRate = value;
+  storedConfig.altMagRate = value;
 }
 
 uint8_t ShimConfig_configByteAltMagRateGet(void)
@@ -427,97 +428,97 @@ uint8_t ShimConfig_configByteAltMagRateGet(void)
   return storedConfig.altMagRate;
 }
 
-uint8_t ShimConfig_checkAndCorrectConfig(gConfigBytes *storedConfigPtr)
+uint8_t ShimConfig_checkAndCorrectConfig(void)
 {
   uint8_t settingCorrected = 0;
   uint8_t i = 0;
 
-  if (storedConfigPtr->chEnGsr
+  if (storedConfig.chEnGsr
 #if defined(SHIMMER3)
-      && storedConfigPtr->chEnIntADC1)
+      && storedConfig.chEnIntADC1)
 #elif defined(SHIMMER3R)
-      && storedConfigPtr->chEnIntADC3)
+      && storedConfig.chEnIntADC3)
 #endif
   {
 #if defined(SHIMMER3)
     //they are sharing Shimmer3 adc1, so ban intch1 when gsr is on
-    storedConfigPtr->chEnIntADC1 = 0;
+    storedConfig.chEnIntADC1 = 0;
 #elif defined(SHIMMER3R)
-    storedConfigPtr->chEnIntADC3 = 0;
+    storedConfig.chEnIntADC3 = 0;
 #endif
     settingCorrected = 1;
   }
-  if (storedConfigPtr->chEnBridgeAmp
+  if (storedConfig.chEnBridgeAmp
 #if defined(SHIMMER3)
-      && (storedConfigPtr->chEnIntADC13 || storedConfigPtr->chEnIntADC14))
+      && (storedConfig.chEnIntADC13 || storedConfig.chEnIntADC14))
 #elif defined(SHIMMER3R)
-      && (storedConfigPtr->chEnIntADC1 || storedConfigPtr->chEnIntADC2))
+      && (storedConfig.chEnIntADC1 || storedConfig.chEnIntADC2))
 #endif
   {
 #if defined(SHIMMER3)
     //they are sharing adc13 and adc14
-    storedConfigPtr->chEnIntADC13 = 0;
-    storedConfigPtr->chEnIntADC14 = 0;
+    storedConfig.chEnIntADC13 = 0;
+    storedConfig.chEnIntADC14 = 0;
 #elif defined(SHIMMER3R)
-    storedConfigPtr->chEnIntADC1 = 0;
-    storedConfigPtr->chEnIntADC2 = 0;
+    storedConfig.chEnIntADC1 = 0;
+    storedConfig.chEnIntADC2 = 0;
 #endif
     settingCorrected = 1;
   }
-  if (storedConfigPtr->chEnExg1_24Bit && storedConfigPtr->chEnExg1_16Bit)
+  if (storedConfig.chEnExg1_24Bit && storedConfig.chEnExg1_16Bit)
   {
-    storedConfigPtr->chEnExg1_16Bit = 0;
+    storedConfig.chEnExg1_16Bit = 0;
     settingCorrected = 1;
   }
-  if (storedConfigPtr->chEnExg2_24Bit && storedConfigPtr->chEnExg2_16Bit)
+  if (storedConfig.chEnExg2_24Bit && storedConfig.chEnExg2_16Bit)
   {
-    storedConfigPtr->chEnExg2_16Bit = 0;
+    storedConfig.chEnExg2_16Bit = 0;
     settingCorrected = 1;
   }
-  if ((storedConfigPtr->chEnExg1_24Bit || storedConfigPtr->chEnExg2_24Bit
-          || storedConfigPtr->chEnExg1_16Bit || storedConfigPtr->chEnExg2_16Bit)
+  if ((storedConfig.chEnExg1_24Bit || storedConfig.chEnExg2_24Bit
+          || storedConfig.chEnExg1_16Bit || storedConfig.chEnExg2_16Bit)
 #if defined(SHIMMER3)
-      && (storedConfigPtr->chEnIntADC1 || storedConfigPtr->chEnIntADC14))
+      && (storedConfig.chEnIntADC1 || storedConfig.chEnIntADC14))
 #elif defined(SHIMMER3R)
-      && (storedConfigPtr->chEnIntADC3 || storedConfigPtr->chEnIntADC2))
+      && (storedConfig.chEnIntADC3 || storedConfig.chEnIntADC2))
 #endif
   {
 #if defined(SHIMMER3)
-    storedConfigPtr->chEnIntADC1 = 0;
-    storedConfigPtr->chEnIntADC14 = 0;
+    storedConfig.chEnIntADC1 = 0;
+    storedConfig.chEnIntADC14 = 0;
 #elif defined(SHIMMER3R)
-    storedConfigPtr->chEnIntADC3 = 0;
-    storedConfigPtr->chEnIntADC2 = 0;
+    storedConfig.chEnIntADC3 = 0;
+    storedConfig.chEnIntADC2 = 0;
 #endif
     settingCorrected = 1;
   }
 
-  if (storedConfigPtr->chEnSkinTemp || storedConfigPtr->chEnResAmp)
+  if (storedConfig.chEnSkinTemp || storedConfig.chEnResAmp)
   {
 #if defined(SHIMMER3)
-    storedConfigPtr->chEnIntADC1 = 1;
+    storedConfig.chEnIntADC1 = 1;
 #elif defined(SHIMMER3R)
-    storedConfigPtr->chEnIntADC3 = 1;
+    storedConfig.chEnIntADC3 = 1;
 #endif
   }
 
-  if (storedConfigPtr->gsrRange > 4)
+  if (storedConfig.gsrRange > 4)
   { //never larger than 4
-    storedConfigPtr->gsrRange = GSR_AUTORANGE;
+    storedConfig.gsrRange = GSR_AUTORANGE;
     settingCorrected = 1;
   }
 
   //minimum sync broadcast interval is 54 seconds
-  if (storedConfigPtr->syncEnable && storedConfigPtr->btIntervalSecs < SYNC_INT_C)
+  if (storedConfig.syncEnable && storedConfig.btIntervalSecs < SYNC_INT_C)
   {
-    storedConfigPtr->btIntervalSecs = SYNC_INT_C;
+    storedConfig.btIntervalSecs = SYNC_INT_C;
     settingCorrected = 1;
   }
 
 #if !IS_SUPPORTED_TCXO
-  if (storedConfigPtr->tcxo)
+  if (storedConfig.tcxo)
   {
-    storedConfigPtr->tcxo = 0; /* Disable TCXO */
+    storedConfig.tcxo = 0; /* Disable TCXO */
     settingCorrected = 1;
   }
 #endif
@@ -525,38 +526,37 @@ uint8_t ShimConfig_checkAndCorrectConfig(gConfigBytes *storedConfigPtr)
 #if IS_SUPPORTED_SINGLE_TOUCH
   //the button always works for singletouch mode
   //sync always works for singletouch mode
-  if (storedConfigPtr->singleTouchStart
-      && (!storedConfigPtr->userButtonEnable || !storedConfigPtr->syncEnable))
+  if (storedConfig.singleTouchStart
+      && (!storedConfig.userButtonEnable || !storedConfig.syncEnable))
   {
-    storedConfigPtr->userButtonEnable = 1;
-    storedConfigPtr->syncEnable = 1;
+    storedConfig.userButtonEnable = 1;
+    storedConfig.syncEnable = 1;
     settingCorrected = 1;
   }
 #else
-  storedConfigPtr->singleTouchStart = 0;
+  storedConfig.singleTouchStart = 0;
 #endif //IS_SUPPORTED_SINGLE_TOUCH
 
-  if (ShimBrd_areADS1292RClockLinesTied()
-      && !(storedConfigPtr->exgADS1292rRegsCh1.config2 & 0x08))
+  if (ShimBrd_areADS1292RClockLinesTied() && !(storedConfig.exgADS1292rRegsCh1.config2 & 0x08))
   {
     /* Amend configuration byte 2 of ADS chip 1 to have bit 3 set to 1.
      * This ensures clock lines on ADS chip are correct */
-    storedConfigPtr->exgADS1292rRegsCh1.config2 |= 8;
+    storedConfig.exgADS1292rRegsCh1.config2 |= 8;
     settingCorrected = 1;
   }
 
   /* This used to be used to trigger reset of the Bluetooth advertising name
    * and pin code but is no longer needed due to BT driver updates. */
-  if (storedConfigPtr->btPinSetup)
+  if (storedConfig.btPinSetup)
   {
-    storedConfigPtr->btPinSetup = 0;
+    storedConfig.btPinSetup = 0;
     settingCorrected = 1;
   }
 
 #if defined(SHIMMER3)
-  if (!ShimBrd_isWrAccelInUseLsm303dlhc() && storedConfigPtr->magRange != 0)
+  if (!ShimBrd_isWrAccelInUseLsm303dlhc() && storedConfig.magRange != 0)
   {
-    storedConfigPtr->magRange = 0;
+    storedConfig.magRange = 0;
     settingCorrected = 1;
   }
 #endif
@@ -566,9 +566,9 @@ uint8_t ShimConfig_checkAndCorrectConfig(gConfigBytes *storedConfigPtr)
   uint8_t *macIdBytesPtr = ShimBt_macIdBytesPtrGet();
   for (i = 0; i < 6; i++)
   {
-    if (*(macIdBytesPtr + i) != storedConfigPtr->macAddr[i])
+    if (*(macIdBytesPtr + i) != storedConfig.macAddr[i])
     {
-      memcpy(&storedConfigPtr->macAddr[0], macIdBytesPtr, 6);
+      memcpy(&storedConfig.macAddr[0], macIdBytesPtr, 6);
       settingCorrected = 1;
       break;
     }
@@ -577,54 +577,54 @@ uint8_t ShimConfig_checkAndCorrectConfig(gConfigBytes *storedConfigPtr)
   return settingCorrected;
 }
 
-void ShimConfig_setExgConfigForTestSignal(gConfigBytes *storedConfigPtr)
+void ShimConfig_setExgConfigForTestSignal(void)
 {
   //square wave test
-  storedConfigPtr->exgADS1292rRegsCh1.config1 = 0x04;
-  storedConfigPtr->exgADS1292rRegsCh1.config2 = 0xab; //was 0xa3 for rev1
-  storedConfigPtr->exgADS1292rRegsCh1.loff = 0x10;
-  storedConfigPtr->exgADS1292rRegsCh1.ch1set = 0x05;
-  storedConfigPtr->exgADS1292rRegsCh1.ch2set = 0x05;
-  storedConfigPtr->exgADS1292rRegsCh1.rldSens = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.loffSens = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.loffStat = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.resp1 = 0x02;
-  storedConfigPtr->exgADS1292rRegsCh1.resp2 = 0x01;
-  storedConfigPtr->exgADS1292rRegsCh2.config1 = 0x04;
-  storedConfigPtr->exgADS1292rRegsCh2.config2 = 0xa3;
-  storedConfigPtr->exgADS1292rRegsCh2.loff = 0x10;
-  storedConfigPtr->exgADS1292rRegsCh2.ch1set = 0x05;
-  storedConfigPtr->exgADS1292rRegsCh2.ch2set = 0x05;
-  storedConfigPtr->exgADS1292rRegsCh2.rldSens = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.loffSens = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.loffStat = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.resp1 = 0x02;
-  storedConfigPtr->exgADS1292rRegsCh2.resp2 = 0x01;
+  storedConfig.exgADS1292rRegsCh1.config1 = 0x04;
+  storedConfig.exgADS1292rRegsCh1.config2 = 0xab; //was 0xa3 for rev1
+  storedConfig.exgADS1292rRegsCh1.loff = 0x10;
+  storedConfig.exgADS1292rRegsCh1.ch1set = 0x05;
+  storedConfig.exgADS1292rRegsCh1.ch2set = 0x05;
+  storedConfig.exgADS1292rRegsCh1.rldSens = 0x00;
+  storedConfig.exgADS1292rRegsCh1.loffSens = 0x00;
+  storedConfig.exgADS1292rRegsCh1.loffStat = 0x00;
+  storedConfig.exgADS1292rRegsCh1.resp1 = 0x02;
+  storedConfig.exgADS1292rRegsCh1.resp2 = 0x01;
+  storedConfig.exgADS1292rRegsCh2.config1 = 0x04;
+  storedConfig.exgADS1292rRegsCh2.config2 = 0xa3;
+  storedConfig.exgADS1292rRegsCh2.loff = 0x10;
+  storedConfig.exgADS1292rRegsCh2.ch1set = 0x05;
+  storedConfig.exgADS1292rRegsCh2.ch2set = 0x05;
+  storedConfig.exgADS1292rRegsCh2.rldSens = 0x00;
+  storedConfig.exgADS1292rRegsCh2.loffSens = 0x00;
+  storedConfig.exgADS1292rRegsCh2.loffStat = 0x00;
+  storedConfig.exgADS1292rRegsCh2.resp1 = 0x02;
+  storedConfig.exgADS1292rRegsCh2.resp2 = 0x01;
 }
 
-void ShimConfig_setExgConfigForEcg(gConfigBytes *storedConfigPtr)
+void ShimConfig_setExgConfigForEcg(void)
 {
   //ecg
-  storedConfigPtr->exgADS1292rRegsCh1.config1 = 0x02;
-  storedConfigPtr->exgADS1292rRegsCh1.config2 = 0x80;
-  storedConfigPtr->exgADS1292rRegsCh1.loff = 0x10;
-  storedConfigPtr->exgADS1292rRegsCh1.ch1set = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.ch2set = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.rldSens = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.loffSens = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.loffStat = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.resp1 = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh1.resp2 = 0x02;
-  storedConfigPtr->exgADS1292rRegsCh2.config1 = 0x02;
-  storedConfigPtr->exgADS1292rRegsCh2.config2 = 0x80;
-  storedConfigPtr->exgADS1292rRegsCh2.loff = 0x10;
-  storedConfigPtr->exgADS1292rRegsCh2.ch1set = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.ch2set = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.rldSens = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.loffSens = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.loffStat = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.resp1 = 0x00;
-  storedConfigPtr->exgADS1292rRegsCh2.resp2 = 0x02;
+  storedConfig.exgADS1292rRegsCh1.config1 = 0x02;
+  storedConfig.exgADS1292rRegsCh1.config2 = 0x80;
+  storedConfig.exgADS1292rRegsCh1.loff = 0x10;
+  storedConfig.exgADS1292rRegsCh1.ch1set = 0x00;
+  storedConfig.exgADS1292rRegsCh1.ch2set = 0x00;
+  storedConfig.exgADS1292rRegsCh1.rldSens = 0x00;
+  storedConfig.exgADS1292rRegsCh1.loffSens = 0x00;
+  storedConfig.exgADS1292rRegsCh1.loffStat = 0x00;
+  storedConfig.exgADS1292rRegsCh1.resp1 = 0x00;
+  storedConfig.exgADS1292rRegsCh1.resp2 = 0x02;
+  storedConfig.exgADS1292rRegsCh2.config1 = 0x02;
+  storedConfig.exgADS1292rRegsCh2.config2 = 0x80;
+  storedConfig.exgADS1292rRegsCh2.loff = 0x10;
+  storedConfig.exgADS1292rRegsCh2.ch1set = 0x00;
+  storedConfig.exgADS1292rRegsCh2.ch2set = 0x00;
+  storedConfig.exgADS1292rRegsCh2.rldSens = 0x00;
+  storedConfig.exgADS1292rRegsCh2.loffSens = 0x00;
+  storedConfig.exgADS1292rRegsCh2.loffStat = 0x00;
+  storedConfig.exgADS1292rRegsCh2.resp1 = 0x00;
+  storedConfig.exgADS1292rRegsCh2.resp2 = 0x02;
 }
 
 /* Note samplingRate can be either a freq or a ticks value */
@@ -681,8 +681,13 @@ uint8_t ShimConfig_isExpansionBoardPwrEnabled(void)
 
 void ShimConfig_loadSensorConfigAndCalib(void)
 {
+  //Read storedConfig from flash or generate default config if not available
+  ShimConfig_readRam();
+
   ShimCalib_init();
   ShimCalib_initFromConfigBytesAll();
+
+  //Read storedConfig from SD cfg file or update it from RAM if RAM is newer
   if (!shimmerStatus.docked && CheckSdInslot())
   { //sd card ready to access
     if (!shimmerStatus.sdPowerOn)
@@ -707,19 +712,17 @@ void ShimConfig_loadSensorConfigAndCalib(void)
       ShimSdCfgFile_readSdConfiguration();
     }
 
+    //If the calib dump file is available, read it into RAM. Else, generate it.
     if (ShimCalib_file2Ram())
     {
       //fail, i.e. no such file. use current DumpRam to generate a file
       ShimCalib_ram2File();
+      //?
       ShimConfig_readRam();
     }
   }
-  else
-  { //sd card not available
-    ShimConfig_readRam();
-    //CalibFromInfoAll();
-  }
 
+  //TODO should this only be called if calib dump file is available?
   ShimCalib_calibDumpToConfigBytesAndSdHeaderAll(1);
 }
 
@@ -856,7 +859,7 @@ void ShimConfig_configTimeSetFromStr(uint8_t *strPtr, uint8_t strLen)
 
   config_time = atol((char *) &configTimeTextTemp[0]);
 
-  ShimConfig_configTimeSet(&storedConfig, config_time);
+  ShimConfig_configTimeSet(config_time);
 }
 
 void ShimConfig_experimentLengthEstimatedInSecSet(uint16_t value)

--- a/Configuration/shimmer_config.h
+++ b/Configuration/shimmer_config.h
@@ -484,7 +484,7 @@ void ShimConfig_setDefaultConfig(void);
 void ShimConfig_setDefaultShimmerName(void);
 void ShimConfig_setDefaultTrialId(void);
 void ShimConfig_setDefaultConfigTime(void);
-void ShimConfig_configTimeSet(gConfigBytes *storedConfigPtr, uint32_t time);
+void ShimConfig_configTimeSet(uint32_t time);
 uint32_t ShimConfig_configTimeGet(void);
 uint8_t ShimConfig_getFlagWriteCfgToSd(void);
 void ShimConfig_setFlagWriteCfgToSd(uint8_t flag, uint8_t writeToFlash);
@@ -494,25 +494,24 @@ uint8_t ShimConfig_getRamCalibFlag(void);
 void ShimConfig_setRamCalibFlag(uint8_t flag);
 float ShimConfig_getShimmerSamplingFreq(void);
 
-void ShimConfig_gyroRangeSet(gConfigBytes *storedConfigPtr, uint8_t value);
+void ShimConfig_gyroRangeSet(uint8_t value);
 uint8_t ShimConfig_gyroRangeGet(void);
-void ShimConfig_gyroRateSet(gConfigBytes *storedConfigPtr, uint8_t value);
-void ShimConfig_wrAccelLpModeSet(gConfigBytes *storedConfigPtr, uint8_t value);
+void ShimConfig_gyroRateSet(uint8_t value);
+void ShimConfig_wrAccelLpModeSet(uint8_t value);
 uint8_t ShimConfig_wrAccelLpModeGet(void);
 #if defined(SHIMMER3R)
-void ShimConfig_wrAccelModeSet(gConfigBytes *storedConfigPtr, lis2dw12_mode_t value);
+void ShimConfig_wrAccelModeSet(lis2dw12_mode_t value);
 lis2dw12_mode_t ShimConfig_wrAccelModeGet(void);
 #endif
-void ShimConfig_configBytePressureOversamplingRatioSet(gConfigBytes *storedConfigPtr,
-    uint8_t value);
+void ShimConfig_configBytePressureOversamplingRatioSet(uint8_t value);
 uint8_t ShimConfig_configBytePressureOversamplingRatioGet(void);
-void ShimConfig_configByteMagRateSet(gConfigBytes *storedConfigPtr, uint8_t value);
+void ShimConfig_configByteMagRateSet(uint8_t value);
 uint8_t ShimConfig_configByteMagRateGet(void);
-void ShimConfig_configByteAltMagRateSet(gConfigBytes *storedConfigPtr, uint8_t value);
+void ShimConfig_configByteAltMagRateSet(uint8_t value);
 uint8_t ShimConfig_configByteAltMagRateGet(void);
-uint8_t ShimConfig_checkAndCorrectConfig(gConfigBytes *storedConfig);
-void ShimConfig_setExgConfigForTestSignal(gConfigBytes *storedConfigPtr);
-void ShimConfig_setExgConfigForEcg(gConfigBytes *storedConfigPtr);
+uint8_t ShimConfig_checkAndCorrectConfig(void);
+void ShimConfig_setExgConfigForTestSignal(void);
+void ShimConfig_setExgConfigForEcg(void);
 float ShimConfig_freqDiv(float samplingRate);
 void ShimConfig_checkBtModeFromConfig(void);
 #if defined(SHIMMER3R)

--- a/SDCard/shimmer_sd_cfg_file.c
+++ b/SDCard/shimmer_sd_cfg_file.c
@@ -848,8 +848,8 @@ void ShimSdCfgFile_parse(void)
         sizeof(stored_config_temp.altMagCalib.rawBytes));
     triggerSdCardUpdate
         |= ShimConfig_checkAndCorrectConfig(ShimConfig_getStoredConfig());
-    memcpy( &(storedConfig->rawBytes[0]), &(stored_config_temp.rawBytes[0]), STOREDCONFIG_SIZE);
-   
+    memcpy(&(storedConfig->rawBytes[0]), &(stored_config_temp.rawBytes[0]), STOREDCONFIG_SIZE);
+
     LogAndStream_infomemUpdate();
     /* If the configuration needed to be corrected, update the config file */
     if (triggerSdCardUpdate)

--- a/SDCard/shimmer_sd_cfg_file.c
+++ b/SDCard/shimmer_sd_cfg_file.c
@@ -848,9 +848,9 @@ void ShimSdCfgFile_parse(void)
         sizeof(stored_config_temp.altMagCalib.rawBytes));
     triggerSdCardUpdate
         |= ShimConfig_checkAndCorrectConfig(ShimConfig_getStoredConfig());
-
+    memcpy( &(storedConfig->rawBytes[0]), &(stored_config_temp.rawBytes[0]), STOREDCONFIG_SIZE);
+   
     LogAndStream_infomemUpdate();
-
     /* If the configuration needed to be corrected, update the config file */
     if (triggerSdCardUpdate)
     {

--- a/SDCard/shimmer_sd_cfg_file.c
+++ b/SDCard/shimmer_sd_cfg_file.c
@@ -348,8 +348,7 @@ void ShimSdCfgFile_parse(void)
   uint8_t triggerSdCardUpdate = 0;
 
   CheckSdInslot();
-  gConfigBytes *storedConfig
-      = ShimConfig_getStoredConfig(); //get the pointer as variable is not accessible
+  gConfigBytes *storedConfigPtr = ShimConfig_getStoredConfig();
   char cfgname[] = "sdlog.cfg";
   cfg_file_status = f_open(&cfgFile, cfgname, FA_READ | FA_OPEN_EXISTING);
   if (cfg_file_status == FR_NO_FILE)
@@ -366,27 +365,24 @@ void ShimSdCfgFile_parse(void)
   }
   else
   {
-    gConfigBytes stored_config_temp;
-    /* update  stored_config_temp with original storedConfig contents before
-    parsing from cfg file to check and update the values from cfg_file */
-    memcpy(&(stored_config_temp.rawBytes[0]), &(storedConfig->rawBytes[0]), STOREDCONFIG_SIZE);
+    /* Backup configuration bytes before parsing from cfg file */
+    gConfigBytes storedConfigTemp;
+    memcpy(&(storedConfigTemp.rawBytes[0]), &(storedConfigPtr->rawBytes[0]), STOREDCONFIG_SIZE);
+
     //Reset global configuration bytes to a blank state before parsing the config file.
     ShimConfig_createBlankConfigBytes();
     ShimSdSync_resetSyncVariablesBeforeParseConfig();
     ShimSdSync_resetSyncNodeArray();
 
-    InfoMem_read(NV_SD_CONFIG_DELAY_FLAG,
-        &stored_config_temp.rawBytes[NV_SD_CONFIG_DELAY_FLAG], 1);
-
 #if defined(SHIMMER3)
-    stored_config_temp.rawBytes[NV_SD_TRIAL_CONFIG0] &= ~SDH_SET_PMUX; //PMUX reserved as 0
+    storedConfigPtr->rawBytes[NV_SD_TRIAL_CONFIG0] &= ~SDH_SET_PMUX; //PMUX reserved as 0
 //stored_config_temp.rawBytes[NV_SD_TRIAL_CONFIG0] |= SDH_TIME_STAMP; //TIME_STAMP always = 1
 #endif
-    stored_config_temp.gsrRange = GSR_AUTORANGE;
-    stored_config_temp.bufferSize = 1;
-    stored_config_temp.btCommsBaudRate = getDefaultBaudForBtVersion();
-    stored_config_temp.bluetoothDisable = 0;
-    stored_config_temp.btIntervalSecs = SYNC_INT_C;
+    storedConfigPtr->gsrRange = GSR_AUTORANGE;
+    storedConfigPtr->bufferSize = 1;
+    storedConfigPtr->btCommsBaudRate = getDefaultBaudForBtVersion();
+    storedConfigPtr->bluetoothDisable = 0;
+    storedConfigPtr->btIntervalSecs = SYNC_INT_C;
 
     while (f_gets(buffer, 64, &cfgFile))
     {
@@ -397,129 +393,129 @@ void ShimSdCfgFile_parse(void)
       equals++; //this is the value
       if (strstr(buffer, "accel="))
       {
-        stored_config_temp.chEnLnAccel = atoi(equals);
+        storedConfigPtr->chEnLnAccel = atoi(equals);
       }
       else if (strstr(buffer, "gyro="))
       {
-        stored_config_temp.chEnGyro = atoi(equals);
+        storedConfigPtr->chEnGyro = atoi(equals);
       }
       else if (strstr(buffer, "mag="))
       {
-        stored_config_temp.chEnMag = atoi(equals);
+        storedConfigPtr->chEnMag = atoi(equals);
       }
       else if (strstr(buffer, "exg1_24bit="))
       {
-        stored_config_temp.chEnExg1_24Bit = atoi(equals);
+        storedConfigPtr->chEnExg1_24Bit = atoi(equals);
       }
       else if (strstr(buffer, "exg2_24bit="))
       {
-        stored_config_temp.chEnExg2_24Bit = atoi(equals);
+        storedConfigPtr->chEnExg2_24Bit = atoi(equals);
       }
       else if (strstr(buffer, "gsr="))
       {
-        stored_config_temp.chEnGsr = atoi(equals);
+        storedConfigPtr->chEnGsr = atoi(equals);
       }
 #if defined(SHIMMER3)
       else if (strstr(buffer, "extch7="))
       {
-        stored_config_temp.chEnExtADC7 = atoi(equals);
+        storedConfigPtr->chEnExtADC7 = atoi(equals);
       }
       else if (strstr(buffer, "extch6="))
       {
-        stored_config_temp.chEnExtADC6 = atoi(equals);
+        storedConfigPtr->chEnExtADC6 = atoi(equals);
       }
 #elif defined(SHIMMER3R)
       else if (strstr(buffer, "extch0="))
       {
-        stored_config_temp.chEnExtADC0 = atoi(equals);
+        storedConfigPtr->chEnExtADC0 = atoi(equals);
       }
       else if (strstr(buffer, "extch1="))
       {
-        stored_config_temp.chEnExtADC1 = atoi(equals);
+        storedConfigPtr->chEnExtADC1 = atoi(equals);
       }
 #endif
       else if (strstr(buffer, "str=") || strstr(buffer, "br_amp="))
       {
-        stored_config_temp.chEnBridgeAmp = atoi(equals);
+        storedConfigPtr->chEnBridgeAmp = atoi(equals);
       }
       else if (strstr(buffer, "vbat="))
       {
-        stored_config_temp.chEnVBattery = atoi(equals);
+        storedConfigPtr->chEnVBattery = atoi(equals);
       }
       else if (strstr(buffer, "accel_d="))
       {
-        stored_config_temp.chEnWrAccel = atoi(equals);
+        storedConfigPtr->chEnWrAccel = atoi(equals);
       }
 #if defined(SHIMMER3)
       else if (strstr(buffer, "extch15="))
       {
-        stored_config_temp.chEnExtADC15 = atoi(equals);
+        storedConfigPtr->chEnExtADC15 = atoi(equals);
       }
       else if (strstr(buffer, "intch1="))
       {
-        stored_config_temp.chEnIntADC1 = atoi(equals);
+        storedConfigPtr->chEnIntADC1 = atoi(equals);
       }
       else if (strstr(buffer, "intch12="))
       {
-        stored_config_temp.chEnIntADC12 = atoi(equals);
+        storedConfigPtr->chEnIntADC12 = atoi(equals);
       }
       else if (strstr(buffer, "intch13="))
       {
-        stored_config_temp.chEnIntADC13 = atoi(equals);
+        storedConfigPtr->chEnIntADC13 = atoi(equals);
       }
       else if (strstr(buffer, "intch14="))
       {
-        stored_config_temp.chEnIntADC14 = atoi(equals);
+        storedConfigPtr->chEnIntADC14 = atoi(equals);
       }
       else if (strstr(buffer, "accel_mpu="))
       {
-        stored_config_temp.chEnAltAccel = atoi(equals);
+        storedConfigPtr->chEnAltAccel = atoi(equals);
       }
       else if (strstr(buffer, "mag_mpu="))
       {
-        stored_config_temp.chEnAltMag = atoi(equals);
+        storedConfigPtr->chEnAltMag = atoi(equals);
       }
 #elif defined(SHIMMER3R)
       else if (strstr(buffer, "extch2="))
       {
-        stored_config_temp.chEnExtADC2 = atoi(equals);
+        storedConfigPtr->chEnExtADC2 = atoi(equals);
       }
       else if (strstr(buffer, "intch3="))
       {
-        stored_config_temp.chEnIntADC3 = atoi(equals);
+        storedConfigPtr->chEnIntADC3 = atoi(equals);
       }
       else if (strstr(buffer, "intch0="))
       {
-        stored_config_temp.chEnIntADC0 = atoi(equals);
+        storedConfigPtr->chEnIntADC0 = atoi(equals);
       }
       else if (strstr(buffer, "intch1="))
       {
-        stored_config_temp.chEnIntADC1 = atoi(equals);
+        storedConfigPtr->chEnIntADC1 = atoi(equals);
       }
       else if (strstr(buffer, "intch2="))
       {
-        stored_config_temp.chEnIntADC2 = atoi(equals);
+        storedConfigPtr->chEnIntADC2 = atoi(equals);
       }
       else if (strstr(buffer, "accel_alt="))
       {
-        stored_config_temp.chEnAltAccel = atoi(equals);
+        storedConfigPtr->chEnAltAccel = atoi(equals);
       }
       else if (strstr(buffer, "mag_alt="))
       {
-        stored_config_temp.chEnAltMag = atoi(equals);
+        storedConfigPtr->chEnAltMag = atoi(equals);
       }
 #endif
       else if (strstr(buffer, "exg1_16bit="))
       {
-        stored_config_temp.chEnExg1_16Bit = atoi(equals);
+        storedConfigPtr->chEnExg1_16Bit = atoi(equals);
       }
       else if (strstr(buffer, "exg2_16bit="))
       {
-        stored_config_temp.chEnExg2_16Bit = atoi(equals);
+        storedConfigPtr->chEnExg2_16Bit = atoi(equals);
       }
       else if (strstr(buffer, "pres="))
       {
-        stored_config_temp.chEnPressureAndTemperature = atoi(equals);
+        storedConfigPtr->chEnPressureAndTemperature = atoi(equals);
       }
       else if (strstr(buffer, "sample_rate="))
       {
@@ -527,45 +523,45 @@ void ShimSdCfgFile_parse(void)
       }
       else if (strstr(buffer, "mg_internal_rate="))
       {
-        ShimConfig_configByteMagRateSet(&stored_config_temp, atoi(equals));
+        ShimConfig_configByteMagRateSet(atoi(equals));
       }
 #if defined(SHIMMER3)
       else if (strstr(buffer, "mg_range="))
       {
-        stored_config_temp.magRange = atoi(equals);
+        storedConfigPtr->magRange = atoi(equals);
       }
 #else
       else if (strstr(buffer, "mag_alt_range="))
       {
-        stored_config_temp.altMagRange = atoi(equals);
+        storedConfigPtr->altMagRange = atoi(equals);
       }
 #endif
       else if (strstr(buffer, "acc_internal_rate="))
       {
-        stored_config_temp.wrAccelRate = atoi(equals);
+        storedConfigPtr->wrAccelRate = atoi(equals);
       }
 #if defined(SHIMMER3)
       else if (strstr(buffer, "accel_alt_range="))
       {
-        stored_config_temp.altAccelRange = atoi(equals);
+        storedConfigPtr->altAccelRange = atoi(equals);
       }
 #elif defined(SHIMMER3R)
       else if (strstr(buffer, "accel_ln_range="))
       {
-        stored_config_temp.lnAccelRange = atoi(equals);
+        storedConfigPtr->lnAccelRange = atoi(equals);
       }
 #endif
       else if (strstr(buffer, "acc_range="))
       {
-        stored_config_temp.wrAccelRange = atoi(equals);
+        storedConfigPtr->wrAccelRange = atoi(equals);
       }
       else if (strstr(buffer, "acc_lpm="))
       {
-        ShimConfig_wrAccelLpModeSet(&stored_config_temp, atoi(equals));
+        ShimConfig_wrAccelLpModeSet(atoi(equals));
       }
       else if (strstr(buffer, "acc_hrm="))
       {
-        stored_config_temp.wrAccelHrMode = atoi(equals);
+        storedConfigPtr->wrAccelHrMode = atoi(equals);
       }
       else if (strstr(buffer, "gsr_range="))
       { //or "gsr_range="?
@@ -575,108 +571,107 @@ void ShimSdCfgFile_parse(void)
           gsr_range = 4;
         }
 
-        stored_config_temp.gsrRange = gsr_range;
+        storedConfigPtr->gsrRange = gsr_range;
       }
       else if (strstr(buffer, "gyro_samplingrate="))
       {
-        ShimConfig_gyroRateSet(&stored_config_temp, atoi(equals));
+        ShimConfig_gyroRateSet(atoi(equals));
       }
       else if (strstr(buffer, "gyro_range="))
       {
-        ShimConfig_gyroRangeSet(&stored_config_temp, atoi(equals));
+        ShimConfig_gyroRangeSet(atoi(equals));
       }
 #if defined(SHIMMER3)
       else if (strstr(buffer, "pres_bmp180_prec=") || strstr(buffer, "pres_bmp280_prec="))
       {
-        ShimConfig_configBytePressureOversamplingRatioSet(&stored_config_temp, atoi(equals));
+        ShimConfig_configBytePressureOversamplingRatioSet(atoi(equals));
       }
 #elif defined(SHIMMER3R)
       else if (strstr(buffer, "pres_bmp390_prec="))
       {
-        ShimConfig_configBytePressureOversamplingRatioSet(&stored_config_temp, atoi(equals));
+        ShimConfig_configBytePressureOversamplingRatioSet(atoi(equals));
       }
 #endif
 
 #if defined(SHIMMER3R)
       else if (strstr(buffer, "mag_alt_rate="))
       {
-        ShimConfig_configByteAltMagRateSet(&stored_config_temp, atoi(equals));
+        ShimConfig_configByteAltMagRateSet(atoi(equals));
       }
       else if (strstr(buffer, "accel_alt_rate="))
       {
-        stored_config_temp.altAccelRate = atoi(equals);
+        storedConfigPtr->altAccelRate = atoi(equals);
       }
 #endif
       else if (strstr(buffer, "rtc_error_enable="))
       {
-        stored_config_temp.rtcErrorEnable = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->rtcErrorEnable = (atoi(equals) == 0) ? 0 : 1;
       }
       else if (strstr(buffer, "sd_error_enable="))
       {
-        stored_config_temp.sdErrorEnable = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->sdErrorEnable = (atoi(equals) == 0) ? 0 : 1;
       }
       else if (strstr(buffer, "user_button_enable="))
       {
-        stored_config_temp.userButtonEnable = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->userButtonEnable = (atoi(equals) == 0) ? 0 : 1;
       }
       else if (strstr(buffer, "iammaster="))
       { //0=slave=node
-        stored_config_temp.masterEnable = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->masterEnable = (atoi(equals) == 0) ? 0 : 1;
       }
       else if (strstr(buffer, "sync="))
       {
-        stored_config_temp.syncEnable = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->syncEnable = (atoi(equals) == 0) ? 0 : 1;
       }
       else if (strstr(buffer, "bluetoothDisabled="))
       {
-        stored_config_temp.bluetoothDisable = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->bluetoothDisable = (atoi(equals) == 0) ? 0 : 1;
       }
       else if (strstr(buffer, "low_battery_autostop="))
       {
-        stored_config_temp.lowBatteryAutoStop = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->lowBatteryAutoStop = (atoi(equals) == 0) ? 0 : 1;
       }
       else if (strstr(buffer, "interval="))
       {
-        stored_config_temp.btIntervalSecs = atoi(equals) > 255 ? 255 : atoi(equals);
+        storedConfigPtr->btIntervalSecs = atoi(equals) > 255 ? 255 : atoi(equals);
       }
       else if (strstr(buffer, "exp_power="))
       {
-        stored_config_temp.expansionBoardPower = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->expansionBoardPower = (atoi(equals) == 0) ? 0 : 1;
       }
       else if (strstr(buffer, "center="))
       {
-        ShimSdSync_parseSyncCenterNameFromCfgFile(&stored_config_temp.rawBytes[0], equals);
+        ShimSdSync_parseSyncCenterNameFromCfgFile(&storedConfigPtr->rawBytes[0], equals);
       }
       else if (strstr(buffer, "node"))
       {
-        ShimSdSync_parseSyncNodeNameFromCfgFile(&stored_config_temp.rawBytes[0], equals);
+        ShimSdSync_parseSyncNodeNameFromCfgFile(&storedConfigPtr->rawBytes[0], equals);
       }
       else if (strstr(buffer, "est_exp_len="))
       {
         est_exp_len = atoi(equals);
-        stored_config_temp.experimentLengthEstimatedInSecMsb
-            = (est_exp_len & 0xff00) >> 8;
-        stored_config_temp.experimentLengthEstimatedInSecLsb = est_exp_len & 0xff;
+        storedConfigPtr->experimentLengthEstimatedInSecMsb = (est_exp_len & 0xff00) >> 8;
+        storedConfigPtr->experimentLengthEstimatedInSecLsb = est_exp_len & 0xff;
       }
       else if (strstr(buffer, "max_exp_len="))
       {
         max_exp_len = atoi(equals);
-        stored_config_temp.experimentLengthMaxInMinutesMsb = (max_exp_len & 0xff00) >> 8;
-        stored_config_temp.experimentLengthMaxInMinutesLsb = max_exp_len & 0xff;
+        storedConfigPtr->experimentLengthMaxInMinutesMsb = (max_exp_len & 0xff00) >> 8;
+        storedConfigPtr->experimentLengthMaxInMinutesLsb = max_exp_len & 0xff;
       }
 #if IS_SUPPORTED_SINGLE_TOUCH
       else if (strstr(buffer, "singletouch="))
       {
-        stored_config_temp.singleTouchStart = (atoi(equals) == 0) ? 0 : 1;
+        storedConfigPtr->singleTouchStart = (atoi(equals) == 0) ? 0 : 1;
       }
 #endif //IS_SUPPORTED_SINGLE_TOUCH
       else if (strstr(buffer, "myid="))
       {
-        stored_config_temp.myTrialID = atoi(equals);
+        storedConfigPtr->myTrialID = atoi(equals);
       }
       else if (strstr(buffer, "Nshimmer="))
       {
-        stored_config_temp.numberOfShimmers = atoi(equals);
+        storedConfigPtr->numberOfShimmers = atoi(equals);
       }
       else if (strstr(buffer, "shimmername="))
       {
@@ -693,7 +688,7 @@ void ShimSdCfgFile_parse(void)
         {
           string_length = 0;
         }
-        memcpy(&stored_config_temp.shimmerName[0], equals, string_length);
+        memcpy(&storedConfigPtr->shimmerName[0], equals, string_length);
       }
       else if (strstr(buffer, "experimentid="))
       {
@@ -710,113 +705,113 @@ void ShimSdCfgFile_parse(void)
         {
           string_length = 0;
         }
-        memcpy(&stored_config_temp.expIdName[0], equals, string_length);
+        memcpy(&storedConfigPtr->expIdName[0], equals, string_length);
       }
       else if (strstr(buffer, "configtime="))
       {
         config_time = atol(equals);
-        ShimConfig_configTimeSet(&stored_config_temp, config_time);
+        ShimConfig_configTimeSet(config_time);
       }
 
       else if (strstr(buffer, "EXG_ADS1292R_1_CONFIG1="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.config1 = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.config1 = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_CONFIG2="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.config2 = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.config2 = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_LOFF="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.loff = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.loff = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_CH1SET="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.ch1set = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.ch1set = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_CH2SET="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.ch2set = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.ch2set = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_RLD_SENS="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.rldSens = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.rldSens = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_LOFF_SENS="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.loffSens = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.loffSens = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_LOFF_STAT="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.loffStat = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.loffStat = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_RESP1="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.resp1 = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.resp1 = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_1_RESP2="))
       {
-        stored_config_temp.exgADS1292rRegsCh1.resp2 = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh1.resp2 = atoi(equals);
       }
 
       else if (strstr(buffer, "EXG_ADS1292R_2_CONFIG1="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.config1 = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.config1 = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_CONFIG2="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.config2 = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.config2 = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_LOFF="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.loff = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.loff = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_CH1SET="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.ch1set = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.ch1set = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_CH2SET="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.ch2set = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.ch2set = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_RLD_SENS="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.rldSens = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.rldSens = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_LOFF_SENS="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.loffSens = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.loffSens = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_LOFF_STAT="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.loffStat = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.loffStat = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_RESP1="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.resp1 = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.resp1 = atoi(equals);
       }
       else if (strstr(buffer, "EXG_ADS1292R_2_RESP2="))
       {
-        stored_config_temp.exgADS1292rRegsCh2.resp2 = atoi(equals);
+        storedConfigPtr->exgADS1292rRegsCh2.resp2 = atoi(equals);
       }
 
       else if (strstr(buffer, "derived_channels="))
       {
         derived_channels_val = atoll(equals);
-        stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_0] = derived_channels_val & 0xFF;
-        stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_1]
+        storedConfigPtr->rawBytes[NV_DERIVED_CHANNELS_0] = derived_channels_val & 0xFF;
+        storedConfigPtr->rawBytes[NV_DERIVED_CHANNELS_1]
             = (derived_channels_val >> 8) & 0xFF;
-        stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_2]
+        storedConfigPtr->rawBytes[NV_DERIVED_CHANNELS_2]
             = (derived_channels_val >> 16) & 0xFF;
-        stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_3]
+        storedConfigPtr->rawBytes[NV_DERIVED_CHANNELS_3]
             = (derived_channels_val >> 24) & 0xFF;
-        stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_4]
+        storedConfigPtr->rawBytes[NV_DERIVED_CHANNELS_4]
             = (derived_channels_val >> 32) & 0xFF;
-        stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_5]
+        storedConfigPtr->rawBytes[NV_DERIVED_CHANNELS_5]
             = (derived_channels_val >> 40) & 0xFF;
-        stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_6]
+        storedConfigPtr->rawBytes[NV_DERIVED_CHANNELS_6]
             = (derived_channels_val >> 48) & 0xFF;
-        stored_config_temp.rawBytes[NV_DERIVED_CHANNELS_7]
+        storedConfigPtr->rawBytes[NV_DERIVED_CHANNELS_7]
             = (derived_channels_val >> 56) & 0xFF;
       }
     }
@@ -828,27 +823,32 @@ void ShimSdCfgFile_parse(void)
     HAL_Delay(50); //50ms
 #endif
     sample_period = (round) (ShimConfig_freqDiv(sample_rate));
-    stored_config_temp.samplingRateTicks = (uint16_t) sample_period;
-    /* restoring orignal calibration bytes which is not updated from calib file*/
-    memcpy((storedConfig->lnAccelCalib.rawBytes),
-        &(stored_config_temp.lnAccelCalib.rawBytes),
-        sizeof(stored_config_temp.lnAccelCalib.rawBytes));
-    memcpy((storedConfig->gyroCalib.rawBytes), &(stored_config_temp.gyroCalib.rawBytes),
-        sizeof(stored_config_temp.gyroCalib.rawBytes));
-    memcpy((storedConfig->magCalib.rawBytes), &(stored_config_temp.magCalib.rawBytes),
-        sizeof(stored_config_temp.magCalib.rawBytes));
-    memcpy((storedConfig->wrAccelCalib.rawBytes),
-        &(stored_config_temp.wrAccelCalib.rawBytes),
-        sizeof(stored_config_temp.wrAccelCalib.rawBytes));
-    memcpy((storedConfig->altAccelCalib.rawBytes),
-        &(stored_config_temp.altAccelCalib.rawBytes),
-        sizeof(stored_config_temp.altAccelCalib.rawBytes));
-    memcpy((storedConfig->altMagCalib.rawBytes),
-        &(stored_config_temp.altMagCalib.rawBytes),
-        sizeof(stored_config_temp.altMagCalib.rawBytes));
-    triggerSdCardUpdate
-        |= ShimConfig_checkAndCorrectConfig(ShimConfig_getStoredConfig());
-    memcpy(&(storedConfig->rawBytes[0]), &(stored_config_temp.rawBytes[0]), STOREDCONFIG_SIZE);
+    storedConfigPtr->samplingRateTicks = (uint16_t) sample_period;
+
+    /* restoring original calibration bytes which is not updated from calib file*/
+    memcpy((storedConfigPtr->lnAccelCalib.rawBytes),
+        &(storedConfigTemp.lnAccelCalib.rawBytes),
+        sizeof(storedConfigTemp.lnAccelCalib.rawBytes));
+    memcpy((storedConfigPtr->gyroCalib.rawBytes), &(storedConfigTemp.gyroCalib.rawBytes),
+        sizeof(storedConfigTemp.gyroCalib.rawBytes));
+    memcpy((storedConfigPtr->magCalib.rawBytes), &(storedConfigTemp.magCalib.rawBytes),
+        sizeof(storedConfigTemp.magCalib.rawBytes));
+    memcpy((storedConfigPtr->wrAccelCalib.rawBytes),
+        &(storedConfigTemp.wrAccelCalib.rawBytes),
+        sizeof(storedConfigTemp.wrAccelCalib.rawBytes));
+    memcpy((storedConfigPtr->altAccelCalib.rawBytes),
+        &(storedConfigTemp.altAccelCalib.rawBytes),
+        sizeof(storedConfigTemp.altAccelCalib.rawBytes));
+    memcpy((storedConfigPtr->altMagCalib.rawBytes),
+        &(storedConfigTemp.altMagCalib.rawBytes),
+        sizeof(storedConfigTemp.altMagCalib.rawBytes));
+
+    /* Copy back in the NV_SD_CONFIG_DELAY_FLAG byte. This carries forward whether the CFG and/or config files need to be updated. */
+    //TODO Why would the CFG file need to be updated at this point when we are reading it?
+    storedConfigPtr->rawBytes[NV_SD_CONFIG_DELAY_FLAG]
+        = storedConfigTemp.rawBytes[NV_SD_CONFIG_DELAY_FLAG];
+
+    triggerSdCardUpdate |= ShimConfig_checkAndCorrectConfig();
 
     LogAndStream_infomemUpdate();
     /* If the configuration needed to be corrected, update the config file */


### PR DESCRIPTION
Issue came as part of DEV-306 fix where config bytes were reset in a different way this fix changes that and copies the original bytes back