### PR TITLE
DEV-450 bt stop stream show wrong state in consensys l and s

### DIFF
--- a/Sensing/shimmer_sensing.c
+++ b/Sensing/shimmer_sensing.c
@@ -165,7 +165,6 @@ void ShimSens_startSensing(void)
   if (sdLogPendingStart || streamPendingStart)
   {
     shimmerStatus.sensing = 1;
-    sensing.isFileCreated = 0;
     sensing.isSampling = SAMPLE_NOT_READY;
     ShimSens_configureChannels();
     if (ShimSens_getNumEnabledChannels() == 0)
@@ -240,6 +239,7 @@ void ShimSens_startSensing(void)
   if (sdLogPendingStart)
   {
     shimmerStatus.sdLogging = 1;
+    shimmerStatus.sdlogReady = 0;
     shimmerStatus.sdlogCmd = SD_LOG_CMD_STATE_IDLE;
 
     gConfigBytes *configBytesPtr = ShimConfig_getStoredConfig();
@@ -279,6 +279,7 @@ void ShimSens_stopSensing(uint8_t enableDockUartIfDocked)
   if (ShimSens_shouldStopLogging())
   {
     shimmerStatus.sdLogging = 0;
+    shimmerStatus.sdlogReady = 1;
     shimmerStatus.sdlogCmd = SD_LOG_CMD_STATE_IDLE;
 
     ShimTask_clear(TASK_SDWRITE);

--- a/Sensing/shimmer_sensing.c
+++ b/Sensing/shimmer_sensing.c
@@ -239,7 +239,6 @@ void ShimSens_startSensing(void)
   if (sdLogPendingStart)
   {
     shimmerStatus.sdLogging = 1;
-    shimmerStatus.sdlogReady = 0;
     shimmerStatus.sdlogCmd = SD_LOG_CMD_STATE_IDLE;
 
     gConfigBytes *configBytesPtr = ShimConfig_getStoredConfig();
@@ -279,7 +278,6 @@ void ShimSens_stopSensing(uint8_t enableDockUartIfDocked)
   if (ShimSens_shouldStopLogging())
   {
     shimmerStatus.sdLogging = 0;
-    shimmerStatus.sdlogReady = 1;
     shimmerStatus.sdlogCmd = SD_LOG_CMD_STATE_IDLE;
 
     ShimTask_clear(TASK_SDWRITE);

--- a/Sensing/shimmer_sensing.c
+++ b/Sensing/shimmer_sensing.c
@@ -149,7 +149,7 @@ uint8_t ShimSens_shouldStopLogging(void)
 uint8_t ShimSens_shouldStopStreaming(void)
 {
   return shimmerStatus.btStreaming
-      && (!shimmerStatus.btstreamReady
+      && (shimmerStatus.btstreamReady
           || (shimmerStatus.btstreamCmd == BT_STREAM_CMD_STATE_STOP));
 }
 
@@ -586,7 +586,7 @@ void ShimSens_saveData(void)
   }
 #endif
 #if USE_BT
-  if (!ShimSens_shouldStopStreaming())
+  if (ShimSens_shouldStopStreaming())
   {
     uint8_t crcMode = ShimBt_getCrcMode();
     if (crcMode != CRC_OFF)

--- a/TaskList/shimmer_taskList.c
+++ b/TaskList/shimmer_taskList.c
@@ -130,7 +130,7 @@ void ShimTask_NORM_manage(void)
         //looks hackey but SD ERROR without it.
         if (shimmerStatus.sdLogging && sensing.isFileCreated)
         {
-        ShimSdDataFile_writeToCard();
+          ShimSdDataFile_writeToCard();
         }
         break;
       case TASK_SDLOG_CFG_UPDATE:

--- a/TaskList/shimmer_taskList.c
+++ b/TaskList/shimmer_taskList.c
@@ -127,7 +127,11 @@ void ShimTask_NORM_manage(void)
         ShimBt_instreamStatusRespSend();
         break;
       case TASK_SDWRITE:
+        //looks hackey but SD ERROR without it.
+        if (shimmerStatus.sdLogging && sensing.isFileCreated)
+        {
         ShimSdDataFile_writeToCard();
+        }
         break;
       case TASK_SDLOG_CFG_UPDATE:
         if (!shimmerStatus.docked && !shimmerStatus.sensing && CheckSdInslot()


### PR DESCRIPTION
whenever consensys state is streaming and SDLogging , stopping BT is going to state ready instead of SDLogging
actual logging and data folder is seen in sd card , however consensys shows the wrong state

Wrong state needs to be fixed in software, current fix is to make sure that when device is doing only sd_logging data from BTStreaming buffer should not be transmitted.

Note :- may have to change this as per review , not final fix