### PR TITLE
DEV-427 disable BT/BLE control option for S3R

### DIFF
--- a/Configuration/shimmer_config.c
+++ b/Configuration/shimmer_config.c
@@ -647,8 +647,12 @@ void ShimConfig_checkBtModeFromConfig(void)
      * Leave the SD sync code to turn on/off BT later when required. */
     if ((!shimmerStatus.btSupportEnabled && shimmerStatus.btPowerOn)
         || (shimmerStatus.sdSyncEnabled != shimmerStatus.btInSyncMode)
+        //TODO #ifdef to be removed when DEV-427 is done
+#if defined(SHIMMER3)
         || (ShimEeprom_isBleEnabled() != ShimBt_isBleCurrentlyEnabled())
-        || (ShimEeprom_isBtClassicEnabled() != ShimBt_isBtClassicCurrentlyEnabled()))
+        || (ShimEeprom_isBtClassicEnabled() != ShimBt_isBtClassicCurrentlyEnabled())
+#endif
+        )
     {
       BtStop(0);
     }

--- a/Configuration/shimmer_config.c
+++ b/Configuration/shimmer_config.c
@@ -647,12 +647,12 @@ void ShimConfig_checkBtModeFromConfig(void)
      * Leave the SD sync code to turn on/off BT later when required. */
     if ((!shimmerStatus.btSupportEnabled && shimmerStatus.btPowerOn)
         || (shimmerStatus.sdSyncEnabled != shimmerStatus.btInSyncMode)
-        //TODO #ifdef to be removed when DEV-427 is done
+    //TODO #ifdef to be removed when DEV-427 is done
 #if defined(SHIMMER3)
         || (ShimEeprom_isBleEnabled() != ShimBt_isBleCurrentlyEnabled())
         || (ShimEeprom_isBtClassicEnabled() != ShimBt_isBtClassicCurrentlyEnabled())
 #endif
-        )
+    )
     {
       BtStop(0);
     }


### PR DESCRIPTION
My S3R currently reboots it's BT module 3 times as the S3R doesn't support this setting yet but one of the BLE/BT options was disabled in Consensys:
<img width="737" height="547" alt="image" src="https://github.com/user-attachments/assets/03b43cc5-1eda-43cc-8050-be779afb0259" />
The sensor is not connectable after that point.
