### PR TITLE
DEV-737 changing default USB speed from full to high

### DIFF
--- a/EEPROM/shimmer_eeprom.h
+++ b/EEPROM/shimmer_eeprom.h
@@ -76,8 +76,8 @@ typedef union
     //Byte index 2
     uint8_t bleEnabled       : 1;
     uint8_t btClassicEnabled : 1;
-    /* USB Speed. 0 = HS, 1 = FS (only applicable for Shimmer3R) */
-    uint8_t usbFullSpeed   : 1;
+    /* USB Speed. 1 = HS, 0 = FS (only applicable for Shimmer3R) */
+    uint8_t usbHighSpeed   : 1;
     uint8_t unusedIdx3Bit3 : 1;
     uint8_t unusedIdx3Bit4 : 1;
     uint8_t unusedIdx3Bit5 : 1;


### PR DESCRIPTION
This pull request updates the USB speed flag in the `EEPROM/shimmer_eeprom.h` file to clarify its meaning and improve code readability.

Configuration flag update:

* Renamed the `usbFullSpeed` bitfield to `usbHighSpeed` and inverted its logic: now, a value of `1` indicates High Speed (HS) and `0` indicates Full Speed (FS), which is only applicable for Shimmer3R devices. The comment was updated accordingly.