### PR TITLE
DEV-759 Workaround for GSR spikes while ADC sensing

### DIFF
--- a/Sensing/shimmer_sensing.c
+++ b/Sensing/shimmer_sensing.c
@@ -755,6 +755,15 @@ uint8_t *ShimSens_getDataBuffAtNextWrIdx(void)
   return &sensing.packetBuffers[ShimSens_getPacketBufAtNextWrIdx()].dataBuf[0];
 }
 
+/* Buffer for the most recently completed sample (the write index points at the
+ * sample currently being filled by the DMA, so the previous slot is the last
+ * complete one and is never the DMA's current target - safe to read without a
+ * critical section). */
+uint8_t *ShimSens_getDataBuffAtPrevWrIdx(void)
+{
+  return &sensing.packetBuffers[ShimSens_getPacketBufAtPrevWrIdx()].dataBuf[0];
+}
+
 PACKETBufferTypeDef *ShimSens_getPacketBuffAtWrIdx(void)
 {
   return &sensing.packetBuffers[ShimSens_getPacketBufWrIdx()];
@@ -837,6 +846,11 @@ uint8_t ShimSens_getPacketBufWrIdx(void)
 uint8_t ShimSens_getPacketBufAtNextWrIdx(void)
 {
   return (DATA_BUF_MASK & (sensing.packetBuffWrIdx + 1));
+}
+
+uint8_t ShimSens_getPacketBufAtPrevWrIdx(void)
+{
+  return (DATA_BUF_MASK & (sensing.packetBuffWrIdx - 1));
 }
 
 __weak void ADC_gatherDataStart(void)

--- a/Sensing/shimmer_sensing.c
+++ b/Sensing/shimmer_sensing.c
@@ -755,10 +755,15 @@ uint8_t *ShimSens_getDataBuffAtNextWrIdx(void)
   return &sensing.packetBuffers[ShimSens_getPacketBufAtNextWrIdx()].dataBuf[0];
 }
 
-/* Buffer for the most recently completed sample (the write index points at the
- * sample currently being filled by the DMA, so the previous slot is the last
- * complete one and is never the DMA's current target - safe to read without a
- * critical section). */
+/* Buffer for the slot before the write index. The write index points at the
+ * sample the DMA is currently filling, so the previous slot is never the DMA's
+ * current target and is safe to read without a critical section. Always returns
+ * a valid (non-NULL) pointer.
+ * PRECONDITION: this only holds a completed sample once at least one sample has
+ * been captured. Before that (e.g. right after ShimSens_resetPacketBuffAll()
+ * sets the indices to 0, so "previous" wraps to the last slot) it points at an
+ * idle/uninitialised buffer. Callers must only use it while sampling is active -
+ * the sole caller (battery read, used only when sensing) satisfies this. */
 uint8_t *ShimSens_getDataBuffAtPrevWrIdx(void)
 {
   return &sensing.packetBuffers[ShimSens_getPacketBufAtPrevWrIdx()].dataBuf[0];

--- a/Sensing/shimmer_sensing.c
+++ b/Sensing/shimmer_sensing.c
@@ -762,8 +762,8 @@ uint8_t *ShimSens_getDataBuffAtNextWrIdx(void)
  * PRECONDITION: this only holds a completed sample once at least one sample has
  * been captured. Before that (e.g. right after ShimSens_resetPacketBuffAll()
  * sets the indices to 0, so "previous" wraps to the last slot) it points at an
- * idle/uninitialised buffer. Callers must only use it while sampling is active -
- * the sole caller (battery read, used only when sensing) satisfies this. */
+ * idle/uninitialised buffer. Callers must only use it while sampling is active
+ * - the sole caller (battery read, used only when sensing) satisfies this. */
 uint8_t *ShimSens_getDataBuffAtPrevWrIdx(void)
 {
   return &sensing.packetBuffers[ShimSens_getPacketBufAtPrevWrIdx()].dataBuf[0];

--- a/Sensing/shimmer_sensing.h
+++ b/Sensing/shimmer_sensing.h
@@ -297,6 +297,8 @@ void ShimSens_currentExperimentLengthReset(void);
 void ShimSens_maxExperimentLengthSecsSet(uint16_t expLengthMins);
 uint8_t *ShimSens_getDataBuffAtWrIdx(void);
 uint8_t *ShimSens_getDataBuffAtNextWrIdx(void);
+//Buffer before the write index (the last completed sample). Never NULL, but only
+//holds a completed sample once sampling is underway - see definition for details.
 uint8_t *ShimSens_getDataBuffAtPrevWrIdx(void);
 PACKETBufferTypeDef *ShimSens_getPacketBuffAtWrIdx(void);
 PACKETBufferTypeDef *ShimSens_getPacketBuffAtRdIdx(void);

--- a/Sensing/shimmer_sensing.h
+++ b/Sensing/shimmer_sensing.h
@@ -297,6 +297,7 @@ void ShimSens_currentExperimentLengthReset(void);
 void ShimSens_maxExperimentLengthSecsSet(uint16_t expLengthMins);
 uint8_t *ShimSens_getDataBuffAtWrIdx(void);
 uint8_t *ShimSens_getDataBuffAtNextWrIdx(void);
+uint8_t *ShimSens_getDataBuffAtPrevWrIdx(void);
 PACKETBufferTypeDef *ShimSens_getPacketBuffAtWrIdx(void);
 PACKETBufferTypeDef *ShimSens_getPacketBuffAtRdIdx(void);
 void ShimSens_resetPacketBufferAtIdx(uint8_t index, uint8_t resetAll);
@@ -310,6 +311,7 @@ uint8_t ShimSens_getPacketBuffFullCount(void);
 uint8_t ShimSens_getPacketBufRdIdx(void);
 uint8_t ShimSens_getPacketBufWrIdx(void);
 uint8_t ShimSens_getPacketBufAtNextWrIdx(void);
+uint8_t ShimSens_getPacketBufAtPrevWrIdx(void);
 
 __weak void ADC_gatherDataStart(void);
 

--- a/TaskList/shimmer_taskList.c
+++ b/TaskList/shimmer_taskList.c
@@ -149,11 +149,10 @@ void ShimTask_NORM_manage(void)
         break;
       case TASK_BATT_READ:
 #if defined(SHIMMER3)
-        /* use adc channel2 and mem4, read back battery status every certain period */
-        if (!shimmerStatus.sensing)
-        {
-          manageReadBatt(1);
-        }
+        /* use adc channel2 and mem4, read back battery status every certain period.
+         * Safe to run while sensing: manageReadBatt() applies the ADC-priority
+         * policy so the read never disturbs the ADC sensor stream. */
+        manageReadBatt(1);
 #elif defined(SHIMMER3R)
         manageReadBatt(0);
         RTC_setAlarmBattRead();

--- a/log_and_stream_common.c
+++ b/log_and_stream_common.c
@@ -558,6 +558,33 @@ uint8_t LogAndStream_checkSdInSlot(void)
   return shimmerStatus.sdInserted;
 }
 
+battReadAction_t LogAndStream_getBattReadAction(void)
+{
+  /* Prioritise ADC sensor data over an up-to-date battery value - never let a
+   * battery read disturb the ADC sensor stream:
+   *   1) sensing + VBatt streamed   -> use the latest streamed sample
+   *   2) sensing + another ADC chan -> Shimmer3 shares one ADC with the battery,
+   *        so a read would disturb the sensor data: keep the last value.
+   *        Shimmer3R has a dedicated battery ADC (no collision) so it falls
+   *        through and just takes a fresh measurement
+   *   3) sensing + no ADC channels  -> take a new measurement (nothing to disturb)
+   *   4) not sensing                -> take a new measurement */
+  if (shimmerStatus.sensing)
+  {
+    if (ShimConfig_getStoredConfig()->chEnVBattery)
+    {
+      return BATT_READ_USE_STREAM;
+    }
+#if defined(SHIMMER3)
+    if (sensing.nbrMcuAdcChans)
+    {
+      return BATT_READ_REPEAT_LAST;
+    }
+#endif
+  }
+  return BATT_READ_NEW;
+}
+
 void LogAndStream_processDaughterCardId(void)
 {
   /* Read all from EEPROM if present */

--- a/log_and_stream_common.h
+++ b/log_and_stream_common.h
@@ -14,6 +14,17 @@
 
 #include "log_and_stream_definitions.h"
 
+/* Battery-read policy. ADC sensor data is prioritised over an up-to-date battery
+ * value: a fresh battery measurement (which borrows/uses the ADC) is only taken
+ * when it cannot disturb the ADC sensor stream. See LogAndStream_getBattReadAction(). */
+typedef enum
+{
+  BATT_READ_NEW = 0,     //take a fresh battery measurement now
+  BATT_READ_USE_STREAM,  //sensing + VBatt streamed: use the latest streamed sample
+  BATT_READ_REPEAT_LAST  //Shimmer3 sensing + other ADC channel(s), no VBatt: keep the
+                         //last value - a read on the shared ADC would disturb the data
+} battReadAction_t;
+
 void LogAndStream_init(void);
 void LogAndStream_setBootStage(boot_stage_t bootStageNew);
 boot_stage_t LogAndStream_getBootStage(void);
@@ -33,6 +44,7 @@ void LogAndStream_setupUndock(void);
 void LogAndStream_assignSdToDock(void);
 void LogAndStream_releaseSdToMcu(void);
 uint8_t LogAndStream_checkSdInSlot(void);
+battReadAction_t LogAndStream_getBattReadAction(void);
 void LogAndStream_processDaughterCardId(void);
 void LogAndStream_buildShimmerMacSuffix(char *outBuf, size_t outBufLen);
 void LogAndStream_buildShimmerPrefix(char *outBuf, size_t outBufLen);

--- a/log_and_stream_common.h
+++ b/log_and_stream_common.h
@@ -19,10 +19,10 @@
  * when it cannot disturb the ADC sensor stream. See LogAndStream_getBattReadAction(). */
 typedef enum
 {
-  BATT_READ_NEW = 0,     //take a fresh battery measurement now
-  BATT_READ_USE_STREAM,  //sensing + VBatt streamed: use the latest streamed sample
-  BATT_READ_REPEAT_LAST  //Shimmer3 sensing + other ADC channel(s), no VBatt: keep the
-                         //last value - a read on the shared ADC would disturb the data
+  BATT_READ_NEW = 0,    //take a fresh battery measurement now
+  BATT_READ_USE_STREAM, //sensing + VBatt streamed: use the latest streamed sample
+  BATT_READ_REPEAT_LAST //Shimmer3 sensing + other ADC channel(s), no VBatt: keep the
+                        //last value - a read on the shared ADC would disturb the data
 } battReadAction_t;
 
 void LogAndStream_init(void);


### PR DESCRIPTION
This pull request introduces improvements to how battery readings are managed during sensor data acquisition, ensuring that ADC sensor streams are not disturbed by battery measurements. It also adds new utility functions for accessing previous data buffers in the sensing module. The most important changes are grouped below:

**Battery Read Policy Improvements:**

* Introduced a new `battReadAction_t` enum and a function `LogAndStream_getBattReadAction()` to determine when and how to take battery measurements, prioritizing uninterrupted ADC sensor data over up-to-date battery values. The policy ensures that battery reads do not interfere with sensor data collection, especially on platforms where the ADC is shared. (`log_and_stream_common.h` [[1]](diffhunk://#diff-3d046931d75901c9fcc61aa6850aa718003c1794aba1b9d12180b9245e0ba180R17-R27) [[2]](diffhunk://#diff-3d046931d75901c9fcc61aa6850aa718003c1794aba1b9d12180b9245e0ba180R47); `log_and_stream_common.c` [[3]](diffhunk://#diff-618ecef84eb262570ef05c3de2bb12e6ff0b37bb574c3309a38546118f599415R561-R587)
* Updated battery read logic in `ShimTask_NORM_manage()` to always allow battery status checks during sensing, relying on the new ADC-priority policy for safe operation. (`shimmer_taskList.c` [TaskList/shimmer_taskList.cL152-L156](diffhunk://#diff-53cc202e4fc776cd7e96a5433888686390aba5057cb721913d774f1ac2ecd6afL152-L156))

**Sensing Buffer Utilities:**

* Added new functions `ShimSens_getDataBuffAtPrevWrIdx()` and `ShimSens_getPacketBufAtPrevWrIdx()` to access the most recently completed sample buffer (the slot just before the current write index), and declared them in the header file. These functions are safe to use without critical sections as they never overlap with DMA operations. (`shimmer_sensing.c` [[1]](diffhunk://#diff-0c7a3b422bb97167cbd12c2a9d5701110cf058dad27c4fac963ed9a22b401475R758-R766) [[2]](diffhunk://#diff-0c7a3b422bb97167cbd12c2a9d5701110cf058dad27c4fac963ed9a22b401475R851-R855); `shimmer_sensing.h` [[3]](diffhunk://#diff-9c300f118d1129d3a0948d1129bfd53c6f99734714f9521fba62b6b1e52c9401R300) [[4]](diffhunk://#diff-9c300f118d1129d3a0948d1129bfd53c6f99734714f9521fba62b6b1e52c9401R314)